### PR TITLE
Add alt_name_to_ids method for enum value to string mapping

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rich_enums (0.1.4)
+    rich_enums (0.1.5)
       activerecord (>= 6.1, < 8.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ user.role_code # => 'ROLE001'
 user.role_for_database # => 1
 User.roles # => {"admin"=>1, "user"=>2}
 User.role_codes # => {"admin"=>"ROLE001", "user"=>"ROLE101"}
+User.role_alt_name_to_ids # => {"ROLE001"=>1, "ROLE101"=>2}
 
 ```
 
@@ -61,6 +62,7 @@ user.role_alt_name # => 'ROLE001'
 user.role_for_database # => 1
 User.roles # => {"admin"=>1, "user"=>2}
 User.role_alt_names # => {"admin"=>"ROLE001", "user"=>"ROLE101"}
+User.role_alt_name_to_ids # => {"ROLE001"=>1, "ROLE101"=>2}
 ExternalSystem.sync(user.external_id, role_code: user.role_alt_name)
 ```
 Any arguments other than 'alt' are forwarded to the default enum definition.

--- a/lib/rich_enums/version.rb
+++ b/lib/rich_enums/version.rb
@@ -1,3 +1,3 @@
 module RichEnums
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/spec/rich_enums_spec.rb
+++ b/spec/rich_enums_spec.rb
@@ -145,5 +145,29 @@ RSpec.describe RichEnums do
         expect(test_instance.status_name).to eq("NOT_LIVE")
       end
     end
+
+    context "alternate name to ID mapping" do
+      let(:test_class) do
+        Temping.create(:test_class) do
+          with_columns do |t|
+            t.integer :status
+          end
+
+          include RichEnums
+          rich_enum status: {
+            active: [0, 'LIVE'],
+            inactive: [1, 'NOT_LIVE']
+          }, alt: 'name'
+        end
+      end
+
+      it "returns correct mapping of alternate names to enum values" do
+        expected_mapping = {
+          "LIVE" => 0,
+          "NOT_LIVE" => 1
+        }
+        expect(test_class.status_alt_name_to_ids).to eq(expected_mapping)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new class method to rich_enums, which can be used for mapping enum values to string values.

eg:

class User < ApplicationRecord
  rich_enum role: { admin: [1, 'ROLE001'], user: [2, 'ROLE101'] }
end

User.role_alt_name_to_ids 
=> {"ROLE001"=>1, "ROLE101"=>2}